### PR TITLE
Fix repr(Rust) layout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,15 +89,11 @@ pub struct TypeLayoutInfo {
 
 #[derive(Debug)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
-pub enum Field {
-    Field {
-        name: Cow<'static, str>,
-        ty: Cow<'static, str>,
-        size: usize,
-    },
-    Padding {
-        size: usize,
-    },
+pub struct Field {
+    pub name: Cow<'static, str>,
+    pub ty: Cow<'static, str>,
+    pub size: usize,
+    pub offset: usize,
 }
 
 impl fmt::Display for TypeLayoutInfo {
@@ -108,15 +104,22 @@ impl fmt::Display for TypeLayoutInfo {
             self.name, self.size, self.alignment
         )?;
 
+        // Calculate the sum of all fields' sizes to detect if the
+        // struct is padded.
+        let fields_size: usize = self.fields.iter().map(|f| f.size).sum();
+        let padding_header_length = if fields_size < self.size {
+            "[padding]".len()
+        } else {
+            0
+        };
+
         let longest_name = self
             .fields
             .iter()
-            .map(|field| match field {
-                Field::Field { name, .. } => name.len(),
-                Field::Padding { .. } => "[padding]".len(),
-            })
+            .map(|field| field.name.len())
             .max()
-            .unwrap_or(1);
+            .unwrap_or(1)
+            .max(padding_header_length);
 
         let widths = RowWidths {
             offset: "Offset".len(),
@@ -147,26 +150,41 @@ impl fmt::Display for TypeLayoutInfo {
         let mut offset = 0;
 
         for field in &self.fields {
-            match field {
-                Field::Field { name, size, .. } => {
-                    write_row(formatter, widths, Row { offset, name, size })?;
-
-                    offset += size;
-                }
-                Field::Padding { size } => {
-                    write_row(
-                        formatter,
-                        widths,
-                        Row {
-                            offset,
-                            name: "[padding]",
-                            size,
-                        },
-                    )?;
-
-                    offset += size;
-                }
+            if field.offset > offset {
+                write_row(
+                    formatter,
+                    widths,
+                    Row {
+                        offset,
+                        name: "[padding]",
+                        size: field.offset - offset,
+                    },
+                )?;
             }
+
+            write_row(
+                formatter,
+                widths,
+                Row {
+                    offset: field.offset,
+                    name: &*field.name,
+                    size: field.size,
+                },
+            )?;
+            offset = field.offset + field.size;
+        }
+
+        // Handle tail padding.
+        if offset < self.size {
+            write_row(
+                formatter,
+                widths,
+                Row {
+                    offset,
+                    name: "[padding]",
+                    size: self.size - offset,
+                },
+            )?;
         }
 
         Ok(())

--- a/try-crate/src/main.rs
+++ b/try-crate/src/main.rs
@@ -7,6 +7,13 @@ struct Foo {
     b: u16,
 }
 
+#[derive(TypeLayout)]
+struct Bar {
+    a: u8,
+    b: u16,
+}
+
 fn main() {
-    println!("{}", Foo::layout());
+    println!("{}", Foo::type_layout());
+    println!("{}", Bar::type_layout());
 }

--- a/type-layout-derive/src/lib.rs
+++ b/type-layout-derive/src/lib.rs
@@ -27,6 +27,8 @@ pub fn derive_type_layout(input: TokenStream) -> TokenStream {
 
                 #layout
 
+                fields.sort_by_key(|f| f.offset);
+
                 ::type_layout::TypeLayoutInfo {
                     name: ::std::borrow::Cow::Borrowed(#name_str),
                     size: std::mem::size_of::<#name>(),
@@ -57,16 +59,11 @@ fn layout_of_type(struct_name: &Ident, data: &Data) -> proc_macro2::TokenStream 
                             let size = ::std::mem::size_of::<#field_ty>();
                             let offset = ::type_layout::memoffset::offset_of!(#struct_name, #field_name);
 
-                            if offset > last_field_end {
-                                fields.push(::type_layout::Field::Padding {
-                                    size: offset - last_field_end
-                                });
-                            }
-
-                            fields.push(::type_layout::Field::Field {
+                            fields.push(::type_layout::Field {
                                 name: ::std::borrow::Cow::Borrowed(#field_name_str),
                                 ty: ::std::borrow::Cow::Borrowed(#field_ty_str),
                                 size,
+                                offset,
                             });
 
                             last_field_end = offset + size;
@@ -76,13 +73,6 @@ fn layout_of_type(struct_name: &Ident, data: &Data) -> proc_macro2::TokenStream 
 
                 quote! {
                     #(#values)*
-
-                    let struct_size = ::std::mem::size_of::<#struct_name>();
-                    if struct_size > last_field_end {
-                        fields.push(::type_layout::Field::Padding {
-                            size: struct_size - last_field_end,
-                        });
-                    }
                 }
             }
             Fields::Unnamed(_) => unimplemented!(),


### PR DESCRIPTION
 - Added `offset` as a member of `Field`
 - Sort by `offset`
 - Paddings are inserted on format, now in the correct places.

`cargo-run` in `try-crate` now prints
```
Foo (size 4, alignment 2)
| Offset | Name      | Size |
| ------ | --------- | ---- |
| 0      | a         | 1    |
| 1      | [padding] | 1    |
| 2      | b         | 2    |

Bar (size 4, alignment 2)
| Offset | Name      | Size |
| ------ | --------- | ---- |
| 0      | b         | 2    |
| 2      | a         | 1    |
| 3      | [padding] | 1    |
```

It's a bit of a shift from the original, not sure if that's okay or not.