### PR TITLE
Add support for tuple, unit, and generic structs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ pub struct TypeLayoutInfo {
     pub size: usize,
     pub alignment: usize,
     pub fields: Vec<Field>,
+    pub generics: Vec<Cow<'static, str>>,
 }
 
 #[derive(Debug)]
@@ -98,10 +99,14 @@ pub struct Field {
 
 impl fmt::Display for TypeLayoutInfo {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "{}", self.name)?;
+        if !self.generics.is_empty() {
+            write!(formatter, "<{}>", self.generics.join(", "))?;
+        }
         writeln!(
             formatter,
-            "{} (size {}, alignment {})",
-            self.name, self.size, self.alignment
+            " (size {}, alignment {})",
+            self.size, self.alignment
         )?;
 
         // Calculate the sum of all fields' sizes to detect if the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,8 @@ impl fmt::Display for TypeLayoutInfo {
             .map(|field| field.name.len())
             .max()
             .unwrap_or(1)
+            // Relevant for tuple structs where the field names are single-character
+            .max("Name".len())
             .max(padding_header_length);
 
         let widths = RowWidths {

--- a/try-crate/Cargo.toml
+++ b/try-crate/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+expand = "0.2.0"
 type-layout = { path = "..", features = ["serde1"] }

--- a/try-crate/src/main.rs
+++ b/try-crate/src/main.rs
@@ -14,8 +14,11 @@ struct Bar {
 }
 
 #[derive(TypeLayout)]
-struct GenericStruct<T> {
-    f: T,
+struct GenericStruct<'a, T, const N: usize>
+where
+    T: 'a,
+{
+    f: &'a [T; N],
 }
 
 #[derive(TypeLayout)]
@@ -30,7 +33,7 @@ struct Empty;
 fn main() {
     println!("{}", Foo::type_layout());
     println!("{}", Bar::type_layout());
-    println!("{}", GenericStruct::<i32>::type_layout());
+    println!("{}", GenericStruct::<'static, i8, 5>::type_layout());
     println!("{}", TupleStruct::type_layout());
     println!("{}", GenericTupleStruct::<i8>::type_layout());
     println!("{}", Empty::type_layout());

--- a/try-crate/src/main.rs
+++ b/try-crate/src/main.rs
@@ -13,7 +13,25 @@ struct Bar {
     b: u16,
 }
 
+#[derive(TypeLayout)]
+struct GenericStruct<T> {
+    f: T,
+}
+
+#[derive(TypeLayout)]
+struct TupleStruct(i32, i8, i32);
+
+#[derive(TypeLayout)]
+struct GenericTupleStruct<T>(i32, T, i32);
+
+#[derive(TypeLayout)]
+struct Empty;
+
 fn main() {
     println!("{}", Foo::type_layout());
     println!("{}", Bar::type_layout());
+    println!("{}", GenericStruct::<i32>::type_layout());
+    println!("{}", TupleStruct::type_layout());
+    println!("{}", GenericTupleStruct::<i8>::type_layout());
+    println!("{}", Empty::type_layout());
 }

--- a/type-layout-derive/src/lib.rs
+++ b/type-layout-derive/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 
 use proc_macro2::{Ident, Literal};
 use quote::{quote, quote_spanned, ToTokens};
-use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput, Fields};
+use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput, Fields, ImplGenerics};
 
 #[proc_macro_derive(TypeLayout)]
 pub fn derive_type_layout(input: TokenStream) -> TokenStream {
@@ -16,14 +16,16 @@ pub fn derive_type_layout(input: TokenStream) -> TokenStream {
     let name_str = Literal::string(&name.to_string());
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let layout = layout_of_type(&name, &input.data);
+    let layout = layout_of_type(&name, &input.data, &impl_generics);
 
     // Build the output, possibly using quasi-quotation
     let expanded = quote! {
         impl #impl_generics ::type_layout::TypeLayout for #name #ty_generics #where_clause {
             fn type_layout() -> ::type_layout::TypeLayoutInfo {
-                let mut last_field_end = 0;
-                let mut fields = Vec::new();
+                // Need to specify type since it's possible for the struct
+                // to have no fields, thus making "#layout" empty, resulting
+                // in inference failure.
+                let mut fields = Vec::<::type_layout::Field>::new();
 
                 #layout
 
@@ -31,8 +33,8 @@ pub fn derive_type_layout(input: TokenStream) -> TokenStream {
 
                 ::type_layout::TypeLayoutInfo {
                     name: ::std::borrow::Cow::Borrowed(#name_str),
-                    size: std::mem::size_of::<#name>(),
-                    alignment: ::std::mem::align_of::<#name>(),
+                    size: std::mem::size_of::<#name #impl_generics>(),
+                    alignment: ::std::mem::align_of::<#name #impl_generics>(),
                     fields,
                 }
             }
@@ -43,7 +45,11 @@ pub fn derive_type_layout(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-fn layout_of_type(struct_name: &Ident, data: &Data) -> proc_macro2::TokenStream {
+fn layout_of_type(
+    struct_name: &Ident,
+    data: &Data,
+    impl_generics: &ImplGenerics,
+) -> proc_macro2::TokenStream {
     match data {
         Data::Struct(data) => match &data.fields {
             Fields::Named(fields) => {
@@ -57,7 +63,7 @@ fn layout_of_type(struct_name: &Ident, data: &Data) -> proc_macro2::TokenStream 
                         #[allow(unused_assignments)]
                         {
                             let size = ::std::mem::size_of::<#field_ty>();
-                            let offset = ::type_layout::memoffset::offset_of!(#struct_name, #field_name);
+                            let offset = ::type_layout::memoffset::offset_of!(#struct_name #impl_generics, #field_name);
 
                             fields.push(::type_layout::Field {
                                 name: ::std::borrow::Cow::Borrowed(#field_name_str),
@@ -65,8 +71,6 @@ fn layout_of_type(struct_name: &Ident, data: &Data) -> proc_macro2::TokenStream 
                                 size,
                                 offset,
                             });
-
-                            last_field_end = offset + size;
                         }
                     }
                 });
@@ -75,8 +79,35 @@ fn layout_of_type(struct_name: &Ident, data: &Data) -> proc_macro2::TokenStream 
                     #(#values)*
                 }
             }
-            Fields::Unnamed(_) => unimplemented!(),
-            Fields::Unit => unimplemented!(),
+            Fields::Unnamed(fields) => {
+                let values = fields.unnamed.iter().enumerate().map(|(index, field)| {
+                    let field_ty = &field.ty;
+                    let field_ty_str = Literal::string(&field_ty.to_token_stream().to_string());
+
+                    let index_string = index.to_string();
+                    let index = syn::Index::from(index);
+                    quote_spanned! { field.span() =>
+                        #[allow(unused_assignments)]
+                        {
+                            let size = ::std::mem::size_of::<#field_ty>();
+                            let offset = ::type_layout::memoffset::offset_of!(#struct_name #impl_generics, #index);
+
+                            fields.push(::type_layout::Field {
+                                name: ::std::borrow::Cow::Borrowed(#index_string),
+                                ty: ::std::borrow::Cow::Borrowed(#field_ty_str),
+                                size,
+                                offset,
+                            });
+                        }
+                    }
+                });
+
+                quote! {
+                    #(#values)*
+                }
+            }
+            // Unit structs don't really have any fields
+            Fields::Unit => proc_macro2::TokenStream::new(),
         },
         Data::Enum(_) | Data::Union(_) => unimplemented!("type-layout only supports structs"),
     }


### PR DESCRIPTION
Closes #2

Examples output now:
```
Foo (size 4, alignment 2)
| Offset | Name      | Size |
| ------ | --------- | ---- |
| 0      | a         | 1    |
| 1      | [padding] | 1    |
| 2      | b         | 2    |

Bar (size 4, alignment 2)
| Offset | Name      | Size |
| ------ | --------- | ---- |
| 0      | b         | 2    |
| 2      | a         | 1    |
| 3      | [padding] | 1    |

GenericStruct (size 4, alignment 4)
| Offset | Name | Size |
| ------ | ---- | ---- |
| 0      | f    | 4    |

TupleStruct (size 12, alignment 4)
| Offset | Name      | Size |
| ------ | --------- | ---- |
| 0      | 0         | 4    |
| 4      | 2         | 4    |
| 8      | 1         | 1    |
| 9      | [padding] | 3    |

GenericTupleStruct (size 12, alignment 4)
| Offset | Name      | Size |
| ------ | --------- | ---- |
| 0      | 0         | 4    |
| 4      | 2         | 4    |
| 8      | 1         | 1    |
| 9      | [padding] | 3    |

Empty (size 0, alignment 1)
| Offset | Name | Size |
| ------ | ---- | ---- |
```

Still trying to figure out how the write the generics themselves in Display, because otherwise you get funny stuff like:
```
GenericStruct (size 4, alignment 4)
| Offset | Name | Size |
| ------ | ---- | ---- |
| 0      | f    | 4    |

GenericStruct (size 8, alignment 8)
| Offset | Name | Size |
| ------ | ---- | ---- |
| 0      | f    | 8    |
```