### PR TITLE
Fix compilation with generics. Resolve type name for generics in ever…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,16 +69,16 @@ use std::borrow::Cow;
 use std::fmt::{self, Display};
 use std::str;
 
-pub use type_layout_derive::TypeLayout;
-
 #[doc(hidden)]
 pub use memoffset;
+
+pub use type_layout_derive::TypeLayout;
 
 pub trait TypeLayout {
     fn type_layout() -> TypeLayoutInfo;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct TypeLayoutInfo {
     pub name: Cow<'static, str>,
@@ -87,7 +87,7 @@ pub struct TypeLayoutInfo {
     pub fields: Vec<Field>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Field {
     pub name: Cow<'static, str>,

--- a/type-layout-derive/src/lib.rs
+++ b/type-layout-derive/src/lib.rs
@@ -3,7 +3,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 
 use proc_macro2::{Ident, Literal};
-use quote::{quote, quote_spanned, ToTokens};
+use quote::{quote, quote_spanned};
 use syn::{Data, DeriveInput, Fields, parse_macro_input, spanned::Spanned, TypeGenerics};
 
 #[proc_macro_derive(TypeLayout)]
@@ -13,7 +13,6 @@ pub fn derive_type_layout(input: TokenStream) -> TokenStream {
 
     // Used in the quasi-quotation below as `#name`.
     let name = input.ident;
-    let name_str = Literal::string(&name.to_string());
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let layout = layout_of_type(&name, &ty_generics, &input.data);
@@ -51,7 +50,6 @@ fn layout_of_type(struct_name: &Ident, ty_generics: &TypeGenerics, data: &Data) 
                     let field_name = field.ident.as_ref().unwrap();
                     let field_name_str = Literal::string(&field_name.to_string());
                     let field_ty = &field.ty;
-                    let field_ty_str = Literal::string(&field_ty.to_token_stream().to_string());
 
                     quote_spanned! { field.span() =>
                         #[allow(unused_assignments)]

--- a/type-layout-derive/src/lib.rs
+++ b/type-layout-derive/src/lib.rs
@@ -30,7 +30,7 @@ pub fn derive_type_layout(input: TokenStream) -> TokenStream {
                 fields.sort_by_key(|f| f.offset);
 
                 ::type_layout::TypeLayoutInfo {
-                    name: ::std::borrow::Cow::Borrowed(#name_str),
+                    name: ::std::borrow::Cow::Borrowed(::std::any::type_name::<Self>()),
                     size: std::mem::size_of::<#name #ty_generics>(),
                     alignment: ::std::mem::align_of::<#name #ty_generics>(),
                     fields,


### PR DESCRIPTION
Using struct such as
```rust
struct Generic<T, I> {
    vec: Vec<T>,
    var: I,
}
```
would result in compilation error suggesting to add generic parameters. The problem lied in fact that for ``size_of`` and ``align_of`` macro passed type name without generics.

Also after fix mentioned before generated type names for such struct would contain ``Vec < T >`` instead of proper type with specified generics because macro tried to use type name specified in struct definition rather than using Rust functionality to retrieve correct type name, this PR also fixes that.