### PR TITLE
Upgrade to syn v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.34.1"]
+        rust_version: [stable, "1.60.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ members = ["type-layout-derive", "try-crate"]
 [dependencies]
 type-layout-derive = { version = "0.2.0", path = "type-layout-derive" }
 
-memoffset = "0.5"
+memoffset = "0.9"
 serde = { version = "1.0.116", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/LPGhatguy/type-layout"
 readme = "README.md"
 keywords = ["layout", "struct", "type"]
 license = "MIT OR Apache-2.0"
+rust-version = "1.60.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/type-layout-derive/Cargo.toml
+++ b/type-layout-derive/Cargo.toml
@@ -13,6 +13,6 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = "1.0.40"
+syn = "2"
 quote = "1.0.7"
 proc-macro2 = "1.0.21"


### PR DESCRIPTION
This PR just bumps the syn dependency version.

Newer crates use syn v2 and when adding type_layout as a dependency, syn v1 is compiled as well. This leads to clippy lints with `#![warn(clippy::cargo)]` enabled. They must be muted with `#![allow(clippy::multiple_crate_versions)]` right now.

@LPGhatguy syn v2 uses a newer msrv, so it does not compile with the older version in the CI.